### PR TITLE
drush version

### DIFF
--- a/scripts.sh
+++ b/scripts.sh
@@ -97,7 +97,7 @@ function installDrushCommand {
 	local projectName=$2
 	local composerApp=$3
 	echo "Installing drush with composer"
-	composerRequire "${targetDir}" "${projectName}" "drush/drush" "${composerApp}"
+	composerRequire "${targetDir}" "${projectName}" "drush/drush:^10.3" "${composerApp}"
 }
 
 # It runs the drush install command in the given composer project.
@@ -760,7 +760,7 @@ case "${ACTION}" in
 		chmod -R u+w "${LOCAL_DEPLOY_TARGET}/${PROJECT_NAME}/web/sites/default"
 		composerRequireWithDependencies "${LOCAL_DEPLOY_TARGET}" "${PROJECT_NAME}" "civicrm/civicrm-core:~5.37" "${COMPOSER_APP}"
 		composerRequire "${LOCAL_DEPLOY_TARGET}" "${PROJECT_NAME}" "civicrm/civicrm-packages:~5.37" "${COMPOSER_APP}"
-		composerRequire "${LOCAL_DEPLOY_TARGET}" "${PROJECT_NAME}" "civicrm/civicrm-drupal-8:5.37" "${COMPOSER_APP}"
+		composerRequire "${LOCAL_DEPLOY_TARGET}" "${PROJECT_NAME}" "civicrm/civicrm-drupal-8:~5.37" "${COMPOSER_APP}"
 		installCivicrml10n "${SUDO}" "${LOCAL_DEPLOY_TARGET}" "${PROJECT_NAME}" "5.37.0"
 		runCvInstall "${SUDO}" "${LOCAL_DEPLOY_TARGET}" "${PROJECT_NAME}"
 		apacheConfig "${SUDO}" "${LOCAL_DEPLOY_TARGET}" "${PROJECT_NAME}" "${APACHE_CONF_DIR}"


### PR DESCRIPTION
I had a build error using the `ci-build` action:
https://github.com/reflexive-communications/rc-base/runs/4811026933?check_suite_focus=true

I traced it back to a `drush` install error:
```
Installing drush with composer
/usr/local/bin/composer
Require drush/drush.
Warning from https://repo.packagist.org: Support for Composer 1 is deprecated and some packages will not be available. You should upgrade to Composer 2. See https://blog.packagist.com/deprecating-composer-1-support/
Using version ^11.0 for drush/drush
./composer.json has been updated
Loading composer repositories with package information
Warning from https://repo.packagist.org: Support for Composer 1 is deprecated and some packages will not be available. You should upgrade to Composer 2. See https://blog.packagist.com/deprecating-composer-1-support/
Updating dependencies (including require-dev)
Your requirements could not be resolved to an installable set of packages.
```

After setting a more specific (and older) `drush` version: `^10.3` instead of the latest in `composer` the build error was gone:
https://github.com/reflexive-communications/rc-base/runs/4811234985?check_suite_focus=true